### PR TITLE
[#12] 랜덤 질문 생생 로직 추가

### DIFF
--- a/src/main/java/com/kwonjs/questioningmusseukgi/common/response/ApiResponse.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/common/response/ApiResponse.java
@@ -1,7 +1,0 @@
-package com.kwonjs.questioningmusseukgi.common.response;
-
-public record ApiResponse<T> (
-	T data
-){
-
-}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/Generator.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/Generator.java
@@ -1,0 +1,7 @@
+package com.kwonjs.questioningmusseukgi.domain.question.generater;
+
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+
+public interface Generator {
+	Question generate();
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/RandomGenerator.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/RandomGenerator.java
@@ -1,0 +1,29 @@
+package com.kwonjs.questioningmusseukgi.domain.question.generater;
+
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.stereotype.Service;
+
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.question.repository.QuestionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RandomGenerator implements Generator { // 랜덤한 문제를 생성하는 클래스
+
+	private final QuestionRepository questionRepository;
+	private final Random random = new Random();
+
+	@Override
+	public Question generate() { // 현재 가장 단순한 형태로 전체 문제에서 랜덤한 문제 하나를 뽑아서 반환
+
+		List<Question> questions = questionRepository.findAll();
+
+		int randomIndex = random.nextInt(questions.size());
+
+		return questions.get(randomIndex);
+	}
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Question.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Question.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.question.model;
+package com.kwonjs.questioningmusseukgi.domain.question.model;
 
 import static javax.persistence.EnumType.*;
 import static javax.persistence.GenerationType.*;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Subject.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Subject.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Subject {
 
-	JAVA, SPRING, OS, NETWORK, DATABASE, DATA_STRUCTURE, ALGORITHM, ETC;
+	JAVA, SPRING, OS, NETWORK, DATABASE, DATA_STRUCTURE, ALGORITHM, INFRA, GIT, ETC;
 
 	@JsonCreator
 	public static Subject of(String subjectName) {

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Subject.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/model/Subject.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.question.model;
+package com.kwonjs.questioningmusseukgi.domain.question.model;
 
 import java.util.Arrays;
 import java.util.Objects;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,8 @@
+package com.kwonjs.questioningmusseukgi.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/service/QuestionService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/service/QuestionService.java
@@ -1,0 +1,34 @@
+package com.kwonjs.questioningmusseukgi.domain.question.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kwonjs.questioningmusseukgi.domain.question.generater.Generator;
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+
+	private final Map<String, Generator> generatorMap;
+
+	public Question generateBy(User user) { // TODO: 추후에 사용자 설정에 맞춰서 질문을 가져올 수 있도록 확장 및 알고리즘 변경
+		Generator generator = generatorMap.get(user.getGeneratorType() + "Generator");
+
+		log.info("start generate question By {}", generator.getClass().getSimpleName());
+
+		Question question = generator.generate();
+
+		log.info("finish generate question : {}", question);
+
+		return question;
+	}
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/model/User.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/model/User.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.user.model;
+package com.kwonjs.questioningmusseukgi.domain.user.model;
 
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
@@ -46,4 +46,11 @@ public class User {
 
 	private boolean deleted;
 
+	public String getEmail() {
+		return null;
+	}
+
+	public String getPassword() {
+		return null;
+	}
 }

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/common/config/FeignConfig.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/common/config/FeignConfig.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.common.config;
+package com.kwonjs.questioningmusseukgi.global.common.config;
 
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/common/response/ApiResponse.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/common/response/ApiResponse.java
@@ -1,0 +1,7 @@
+package com.kwonjs.questioningmusseukgi.global.common.response;
+
+public record ApiResponse<T> (
+	T data
+){
+
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/common/response/ErrorResponse.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/common/response/ErrorResponse.java
@@ -1,6 +1,6 @@
-package com.kwonjs.questioningmusseukgi.common.response;
+package com.kwonjs.questioningmusseukgi.global.common.response;
 
-import com.kwonjs.questioningmusseukgi.exception.ErrorCode;
+import com.kwonjs.questioningmusseukgi.global.exception.ErrorCode;
 
 public record ErrorResponse(
 	String code,

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ErrorCode.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.exception;
+package com.kwonjs.questioningmusseukgi.global.exception;
 
 import org.springframework.http.HttpStatus;
 
@@ -16,7 +16,14 @@ public enum ErrorCode {
 	MISSING_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C003", "인자가 부족합니다."),
 	NOT_EXIST_API(HttpStatus.BAD_REQUEST, "C004", "요청 주소가 올바르지 않습니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "요청 메서드가 올바르지 않습니다."),
-	HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "접근 권한이 없습니다.");
+	HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "접근 권한이 없습니다."),
+
+	// User
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "유저를 찾을 수 없습니다."),
+
+	// Auth
+	EXPIRED_TOKEN(HttpStatus.FORBIDDEN,"A001","만료된 토큰입니다."),
+	INVALID_TOKEN(HttpStatus.FORBIDDEN,"A002","유효하지 않은 토큰입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.exception;
+package com.kwonjs.questioningmusseukgi.global.exception;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-import com.kwonjs.questioningmusseukgi.common.response.ErrorResponse;
+import com.kwonjs.questioningmusseukgi.global.common.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ServiceException.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ServiceException.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.exception;
+package com.kwonjs.questioningmusseukgi.global.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/scheduler/Scheduler.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/scheduler/Scheduler.java
@@ -1,4 +1,4 @@
-package com.kwonjs.questioningmusseukgi.scheduler;
+package com.kwonjs.questioningmusseukgi.global.scheduler;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;


### PR DESCRIPTION
## ✅ 작업 사항
### 랜덤 질문 생생 로직
- 일단은 단순하게 랜덤한 번호를 생성해 랜덤한 질문을 가져오는 로직을 추가했습니다.([질문 생성 로직 개발](https://github.com/JoosungKwon/Questioning-Musseukgi/pull/13/commits/3de62ee6cdbb656347b4e99649a783e18325bcbf))
#### 중요한 것은 질문 생성을 추상화하여 유저 마다 다른 방식으로 질문을 고를 수 있도록 확장성과 유연성을 확보하는 방향으로 구현하였습니다.
**[간단한 설명]**
- 생성의 역할을 generator로 분리함 -> 인터페이스화
- 즉 다양한 방식으로 생성할 수 있도록 확장 가능성을 열어둠
- 다양한 빈을 주입 받을 수 있도록 Map<String, Generator>을 사용함
- 즉, QuestionService를 통해서 질문 관련 작업을 할 수 있음
- 하지만, 어떤 방식으로 질문을 가져올지는 사람마다 다르게 할 수 있도록 생성로직을 객체화하여 동적으로 변경될 수 있도록 구현함

## 💡 관련 이슈
- resolve #12 