### PR TITLE
[#11] 슬랙 알림 동작 구현 및 스케줄 작업 등록 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/node_modules/

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/NotificationService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/NotificationService.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationService {
 
-	@Value("${service.range}") private int RANGE;
+	@Value("${service.range}") private int RANGE; // 시간 단위
 
 	private final UserService userService;
 	private final QuestionService questionService;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/NotificationService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/NotificationService.java
@@ -1,0 +1,51 @@
+package com.kwonjs.questioningmusseukgi.domain.notification;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.kwonjs.questioningmusseukgi.domain.notification.sender.service.SenderService;
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+import com.kwonjs.questioningmusseukgi.domain.user.service.UserService;
+import com.kwonjs.questioningmusseukgi.domain.question.service.QuestionService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	@Value("${service.range}") private int RANGE;
+
+	private final UserService userService;
+	private final QuestionService questionService;
+	private final SenderService senderService;
+
+	public void sendToQuestionAtTime() {
+		LocalTime start = LocalTime.now();
+		this.sendToQuestionAtTime(start);
+	}
+
+	public void sendToQuestionAtTime(LocalTime startTime) {
+		// 1. 설정한 알림 시각에 보내야 하는 사용자 정보 가져오기 -> 구독자 정보
+		// 1-1. 얼만큼의 범위의 시간에서 사용자를 식별할 것인가?
+		LocalTime start = startTime;
+		LocalTime finish = start.plusMinutes(RANGE);
+
+		List<User> users = userService.getByTime(start, finish);
+
+		log.info("users: {}", users);
+
+		// 2. 해당 사용자에게 보낼 질문 고르기 -> 날짜 별로 설정 -> 추후에 사용자 설정에 맞출 수 있도록 확장
+		for(User user : users) {
+			Question question = questionService.generateBy(user);
+			// 3. 해당 사용자에게 질문 보내기
+			senderService.send(user, question);
+		}
+	}
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/api/NotificationController.java
@@ -1,0 +1,29 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.api;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.time.LocalTime;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kwonjs.questioningmusseukgi.domain.notification.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notification")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping("/start")
+	@ResponseStatus(OK)
+	public void startNotificationOnce() { // 스케줄러 수동 동작 임시 메서드 -> 추후에는 사람에 맞게 해당 사람에게 보낼 수 있도록 수정
+		notificationService.sendToQuestionAtTime(LocalTime.now());
+	}
+
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/exception/SendSlackException.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/exception/SendSlackException.java
@@ -1,5 +1,6 @@
 package com.kwonjs.questioningmusseukgi.domain.notification.exception;
 
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
 import com.kwonjs.questioningmusseukgi.global.exception.ErrorCode;
 import com.kwonjs.questioningmusseukgi.global.exception.ServiceException;
 
@@ -12,8 +13,8 @@ public class SendSlackException extends ServiceException {
 
 	private static final ErrorCode ERROR_CODE = ErrorCode.SLACK_SEND_ERROR;
 
-	public SendSlackException(String... param) {
+	public SendSlackException(User user, String webhookUrl, String channel) {
 		super(ERROR_CODE);
-		log.debug(EXCEPTION_FORMAT, param);
+		log.debug(EXCEPTION_FORMAT, user, webhookUrl, channel);
 	}
 }

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/exception/SendSlackException.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/exception/SendSlackException.java
@@ -1,0 +1,19 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.exception;
+
+import com.kwonjs.questioningmusseukgi.global.exception.ErrorCode;
+import com.kwonjs.questioningmusseukgi.global.exception.ServiceException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SendSlackException extends ServiceException {
+
+	private final String EXCEPTION_FORMAT = "User: {}, webhookUrl: {}, channel: {}";
+
+	private static final ErrorCode ERROR_CODE = ErrorCode.SLACK_SEND_ERROR;
+
+	public SendSlackException(String... param) {
+		super(ERROR_CODE);
+		log.debug(EXCEPTION_FORMAT, param);
+	}
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/Sender.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/Sender.java
@@ -1,0 +1,8 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.sender;
+
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+
+public interface Sender {
+	void sendTo(User user, Question question);
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/service/SenderService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/service/SenderService.java
@@ -1,0 +1,24 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.sender.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.kwonjs.questioningmusseukgi.domain.notification.sender.Sender;
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SenderService {
+
+	private final Map<String, Sender> senderProvider;
+
+	public void send(User user, Question question) {
+		String senderName = user.getSenderName();
+		Sender sender = senderProvider.get(senderName + "Sender");
+		sender.sendTo(user, question);
+	}
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackClient.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackClient.java
@@ -1,0 +1,18 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.sender.slack;
+
+import java.net.URI;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "Client", url = "URL")
+public interface SlackClient {
+
+	@PostMapping
+	void send(
+		URI uri,
+		@RequestBody String payload
+	);
+
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackSender.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackSender.java
@@ -38,7 +38,7 @@ public class SlackSender implements Sender {
 			client.send(URI.create(webhookUrl), objectMapper.writeValueAsString(payload));
 		} catch (IOException e) {
 			log.debug("IOException : {}", e.getMessage());
-			throw new SendSlackException(user.toString(), webhookUrl, channel);
+			throw new SendSlackException(user, webhookUrl, channel);
 		}
 
 	}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackSender.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/sender/slack/SlackSender.java
@@ -1,0 +1,58 @@
+package com.kwonjs.questioningmusseukgi.domain.notification.sender.slack;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kwonjs.questioningmusseukgi.domain.notification.exception.SendSlackException;
+import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+import com.kwonjs.questioningmusseukgi.domain.notification.sender.Sender;
+
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlackSender implements Sender {
+
+	private final SlackClient client;
+	private final ObjectMapper objectMapper;
+
+	public void sendTo(User user, Question question){
+
+		String webhookUrl = user.getSlackWebhookUrl();
+		String channel = user.getChannel();
+
+		log.info("Send to slack webhookUrl: {}, channel: {}", webhookUrl, channel);
+		Payload payload = new Payload(user.getMusseukgiName(), user.getIconEmoji(), channel, question.toTemplate());
+		log.info("Payload: {}", payload);
+
+
+		try {
+			client.send(URI.create(webhookUrl), objectMapper.writeValueAsString(payload));
+		} catch (IOException e) {
+			log.debug("IOException : {}", e.getMessage());
+			throw new SendSlackException(user.toString(), webhookUrl, channel);
+		}
+
+	}
+
+	@ToString
+	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+	@RequiredArgsConstructor
+	class Payload {
+		private final String username;
+		private final String iconEmoji;
+		private final String channel;
+		private final String text;
+	}
+
+}
+
+

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/RandomGenerator.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/generater/RandomGenerator.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kwonjs.questioningmusseukgi.domain.question.model.Question;
 import com.kwonjs.questioningmusseukgi.domain.question.repository.QuestionRepository;
@@ -18,6 +19,7 @@ public class RandomGenerator implements Generator { // 랜덤한 문제를 생�
 	private final Random random = new Random();
 
 	@Override
+	@Transactional(readOnly = true)
 	public Question generate() { // 현재 가장 단순한 형태로 전체 문제에서 랜덤한 문제 하나를 뽑아서 반환
 
 		List<Question> questions = questionRepository.findAll();

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/service/QuestionService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/question/service/QuestionService.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class QuestionService {
 
 	private final Map<String, Generator> generatorMap;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.kwonjs.questioningmusseukgi.domain.user.repository;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	//TODO: 11시 - (0시)12시로 넘어갈 때 문제가 생김 추후에 리팩터링 필요
+	@Query(value = """
+			SELECT u
+			FROM User u
+			WHERE u.notificationTime BETWEEN :startTime AND :finishTime
+			""")
+	List<User> searchUserByTime(@Param("startTime") LocalTime startTime, @Param("finishTime") LocalTime finishTime);
+}

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/service/UserService.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.kwonjs.questioningmusseukgi.domain.user.service;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kwonjs.questioningmusseukgi.domain.user.model.User;
+import com.kwonjs.questioningmusseukgi.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public List<User> getByTime(LocalTime startTime, LocalTime finishTime) {
+		return userRepository.searchUserByTime(startTime, finishTime);
+	}
+}
+

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ErrorCode.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/exception/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
 
 	// Auth
 	EXPIRED_TOKEN(HttpStatus.FORBIDDEN,"A001","만료된 토큰입니다."),
-	INVALID_TOKEN(HttpStatus.FORBIDDEN,"A002","유효하지 않은 토큰입니다.");
+	INVALID_TOKEN(HttpStatus.FORBIDDEN,"A002","유효하지 않은 토큰입니다."),
+
+	//Sender
+	SLACK_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "슬랙 메시지 전송에 실패했습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/kwonjs/questioningmusseukgi/global/scheduler/Scheduler.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/global/scheduler/Scheduler.java
@@ -1,10 +1,14 @@
 package com.kwonjs.questioningmusseukgi.global.scheduler;
 
+import java.time.LocalTime;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+
+import com.kwonjs.questioningmusseukgi.domain.notification.NotificationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,10 +18,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Scheduler {
 
+	private final NotificationService notificationService;
+
 	@Async
 	@Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
 	public void task() {
-
+		notificationService.sendToQuestionAtTime(LocalTime.now());
 	}
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,6 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+
+service:
+  range: 10

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,3 +32,6 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+
+service:
+  range: 10


### PR DESCRIPTION
## ✅ 작업 사항
 #### 알림 서비스 추상화 (https://github.com/JoosungKwon/Questioning-Musseukgi/commit/86b44dc5d876d72b9a5f7597230a86d7b85240c1) 
  - 질문 생성과 유사한 방식으로 추상화 객체 Sender 추가
  - 슬랙과 이메일, 등 여러 방식으로 사용자에 맞게 알림을 보낼 수 있도록 확장의 가능성을 열어둠
 #### NotificationService
- [NotificationService 구현](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/29d5c33df523a7b86fa83228d245634467101319) 
  - 파사드 패턴을 활용하기 
  - QuestionService, UserService, SenderService 의존 관계 분리
- [스케줄링 작업 등록](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/b4d0db6e3d1b26c7596f1014ee7cbe388bb3415f) 
  - 알림 전체 서비스를 스케줄링 작업에 등록
  - 10분 마다 알림 서비스(로직) 동작
  
### 슬랙 알림 서비스 구현
- [Slack으로 메시지를 보내는 SlackSender 구현](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/9b091e3fccb82170faafa119859e9d774c012af3)
  - slack webhook을 이용한 메시지 전송 구현 
- [OpenFeign을 이용한 SlackClient 구현](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/05ab8f5bb387af5c18da9b9156263b0e73c85bb7)
  - 실제 데이터 발송 
  
## 💡 관련 이슈
- resolves #11 