### PR TITLE
[#8] Nginx로 HTTPS 적용

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# .dockerignore
+node_modules
+Dockerfile
+.git
+.gitignore
+.dockerignore
+.env

--- a/.github/workflows/deploy-to-ncp-by-docker.yml
+++ b/.github/workflows/deploy-to-ncp-by-docker.yml
@@ -20,10 +20,27 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      # 환경변수 파일 생성 -> GitHub SecretKey 에서 설정한 내용으로 .env 파일 생성
       - name: Set up Environment
-        run: echo "${{ secrets.ENV_PROPERTIES }}" > ./.env # GitHub SecretKey 에서 설정한 내용으로 .env 파일 생성
+        run: echo "${{ secrets.ENV_PROPERTIES }}" > ./.env
 
-      - name: Send to Environment
+      # Gradle 빌드
+      - name: Build with Gradle
+        run: ./gradlew clean bootJar
+
+      # Nginx 설정 파일을 위한 디렉토리 생성
+      - name: Create Directory for Nginx
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          port: 22
+          script: |
+            mkdir -p /root/nginx/
+
+      # 환경변수 파일 서버로 전달하기
+      - name: Send Environment to Server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.DEV_HOST }}
@@ -32,9 +49,18 @@ jobs:
           source: "./.env"
           target: "/root"
 
-      - name: Build with Gradle
-        run: ./gradlew clean bootJar
+      # Nginx 설정 파일 서버로 전달하기
+      - name: Send nginx.conf to Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.HOST_DEV }}
+          username: ${{ secrets.USERNAME }}
+          port: 22
+          key: ${{ secrets.PRIVATE_KEY }}
+          source: "./nginx/default.conf"
+          target: "/root/nginx"
 
+      # 도커 이미지 빌드 및 푸시
       - name: Docker Build & Push to Hub
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -42,7 +68,7 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/questioning-musseukgi:latest
 
       # 도커 컴포즈 설정 파일 서버로 전달하기(복사 후 붙여넣기)
-      - name: Send to Docker-Compose
+      - name: Send Docker-Compose to Server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.DEV_HOST }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,18 @@
 version: '3'
 services:
+  web:
+    container_name: web
+    image: nginx
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /root/nginx:/etc/nginx/conf.d
+      - /etc/letsencrypt:/etc/letsencrypt
+
   db:
-    container_name: questioning-musseukgi-db
+    container_name: db
     image: mysql
     environment:
       MYSQL_DATABASE: app

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,44 @@
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name questioning-musseukgi.site;
+
+  location /api/ {
+    if ($request_method = 'OPTIONS') {
+              add_header 'Access-Control-Allow-Origin' '*';
+              add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
+              add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+              add_header 'Access-Control-Max-Age' 86400;
+              return 204;
+    }
+    proxy_set_header    Host                $http_host;
+    proxy_set_header    X-Real-IP           $remote_addr;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+
+   return 301 https://$host$request_uri;
+  }
+
+  location /.well-known/acme-challenge/ {
+          allow all;
+          root /var/www/certbot;
+  }
+}
+
+
+server {
+    listen 443 ssl;
+    server_name questioning-musseukgi.site;
+    server_tokens off;
+
+    ssl_certificate /etc/letsencrypt/live/questioning-musseukgi.site/fullchain.pem; # example.org를 도메인으로 변경
+    ssl_certificate_key /etc/letsencrypt/live/questioning-musseukgi.site/privkey.pem; # example.or를 도메인으로 변경
+    include /etc/letsencrypt/options-ssl-default.conf;
+
+    location /api/ {
+        proxy_pass  https://$host$request_uri:8080;
+        proxy_set_header    Host                $http_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,24 +4,34 @@ server {
 
   server_name questioning-musseukgi.site;
 
-  location /api/ {
-    if ($request_method = 'OPTIONS') {
-              add_header 'Access-Control-Allow-Origin' '*';
-              add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
-              add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
-              add_header 'Access-Control-Max-Age' 86400;
-              return 204;
+  location / {
+    if ($host = questioning-musseukgi.site) {
+      return 301 https://$host$request_uri;
     }
+    proxy_pass                              https://$host$request_uri;
     proxy_set_header    Host                $http_host;
     proxy_set_header    X-Real-IP           $remote_addr;
     proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+  }
 
-   return 301 https://$host$request_uri;
+  location /api/ {
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, DELETE, PATCH, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+      add_header 'Access-Control-Max-Age' 86400;
+      return 204;
+    }
+
+    proxy_set_header    Host                $http_host;
+    proxy_set_header    X-Real-IP           $remote_addr;
+    proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+    return 301 https://$host$request_uri;
   }
 
   location /.well-known/acme-challenge/ {
-          allow all;
-          root /var/www/certbot;
+    allow all;
+    root /var/www/certbot;
   }
 }
 
@@ -31,14 +41,23 @@ server {
     server_name questioning-musseukgi.site;
     server_tokens off;
 
-    ssl_certificate /etc/letsencrypt/live/questioning-musseukgi.site/fullchain.pem; # example.org를 도메인으로 변경
-    ssl_certificate_key /etc/letsencrypt/live/questioning-musseukgi.site/privkey.pem; # example.or를 도메인으로 변경
-    include /etc/letsencrypt/options-ssl-default.conf;
+    location / {
+        proxy_pass          http://127.0.0.1:3000;
+        proxy_set_header    Host                $host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_redirect      off;
+    }
 
     location /api/ {
-        proxy_pass  https://$host$request_uri:8080;
+        proxy_pass                              http://127.0.0.1:8080;
         proxy_set_header    Host                $http_host;
         proxy_set_header    X-Real-IP           $remote_addr;
         proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
     }
+
+    ssl_certificate /etc/letsencrypt/live/questioning-musseukgi.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/questioning-musseukgi.site/privkey.pem;
+    include /etc/letsencrypt/options-ssl-default.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 }

--- a/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/api/NotificationController.java
+++ b/src/main/java/com/kwonjs/questioningmusseukgi/domain/notification/api/NotificationController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/notification")
+@RequestMapping("/api/v1/notification")
 public class NotificationController {
 
 	private final NotificationService notificationService;


### PR DESCRIPTION
## ✅ 작업 사항
### Nginx를 사용하여 도메인에 HTTPS 적용하기
- #### Letsencrypt를 통해서 무료 인증서를 발급 받았습니다.
  - 서버에서 작업 진행
  - **참고자료: https://youtu.be/6TYwnURF09w**
  
- #### 발급 받은 인증서를 Nginx에 적용했습니다
  - [nginx로 프론트 서버 엔드포인트 https 적용](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/70316d2977ff22a633745618766e35842bd23cd9)
  - [nginx로 백엔드 API에 https 적용](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/8d954f6f792f58fe7f375af35d6ce1a80b551ec7) 
 
- #### Nginx는 도커로 띄울 수 있도록 배포 과정에 추가했습니다.
  - [docker-compose.yml에 nginx추가](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/eae85d651bcec608eefb8e969a285eca3327889f)
  - [Deploy 스크립트에서 nginx 추가](https://github.com/JoosungKwon/Questioning-Musseukgi/commit/6e55839f1bf4da218ca709432dedbd46f9554ed5) 

#### 이외에도 Nginx로 HTTPS 적용하기, 도커로 Nginx 사용하기, 등 의 주제로 블로그를 참고했습니다.

## 💡 관련 이슈
- resolve #8  